### PR TITLE
Update com.github.neithern.g4music.json

### DIFF
--- a/com.github.neithern.g4music.json
+++ b/com.github.neithern.g4music.json
@@ -1,7 +1,7 @@
 {
     "app-id": "com.github.neithern.g4music",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "46",
+    "runtime-version": "47",
     "sdk": "org.gnome.Sdk",
     "command": "g4music",
     "finish-args": [
@@ -11,8 +11,7 @@
         "--socket=fallback-x11",
         "--socket=pulseaudio",
         "--socket=wayland",
-        "--filesystem=xdg-download:ro",
-        "--filesystem=xdg-music:ro",
+        "--filesystem=xdg-music",
         "--filesystem=xdg-run/gvfsd",
         "--filesystem=xdg-run/pipewire-0:ro",
         "--own-name=org.mpris.MediaPlayer2.Gapless",
@@ -39,7 +38,7 @@
             "sources": [
                 {
                     "type": "git",
-                    "tag": "v3.9.2",
+                    "tag": "v4.0",
                     "url": "https://gitlab.gnome.org/neithern/g4music.git"
                 }
             ]


### PR DESCRIPTION
New features:
- Add music to playlist, edit/rename/remove existing playlists. 
- Drag cover image to re-arrange in a playlist, add to another playlist, or share to another app. 
- Insert music files to playlist drag from another app. 
- Show detail tags in a dialog.
- Move music/playlist file to trash.
- New option: single click to activate item.

Breaking changes:
- Long press an item to enter multiple selection mode. 
- The main queue is editable and recoverable on next startup. 
- Except the main queue, albums/playlists are no longer sortable, but can be random played. 
- Won't switch playing list unless activate manually or play end, open on next startup. 
- Parse ORIGINALDATE/YEAR from Extended-Comment as album's date. 
- Full support of color scheme: System/Light/Dark.
- Don't enable pipewire manually, override the rank if still want to use it. 

Flatpak changes:
- Request writable permission of Music folder for editing playlists.
- Upgrade to GNOME 47.

Optimizings:
- Improve performance of loading large playlist.
- Group popover menu actions.
- Many other optimizings by code refactoring.