### PR TITLE
release v4.5

### DIFF
--- a/com.github.neithern.g4music.json
+++ b/com.github.neithern.g4music.json
@@ -34,7 +34,7 @@
             "sources": [
                 {
                     "type": "git",
-                    "tag": "v4.4",
+                    "tag": "v4.5",
                     "url": "https://gitlab.gnome.org/neithern/g4music.git"
                 }
             ]


### PR DESCRIPTION
Always insert to the next position when play an album. Click index always to open the playing page.
Load the library into the queue only when it is empty.